### PR TITLE
Parse HTML markup in text

### DIFF
--- a/src/components/MarqueeTips.vue
+++ b/src/components/MarqueeTips.vue
@@ -1,5 +1,5 @@
 <template>
-  <p class="marquee-tips">{{content}}</p>
+  <p class="marquee-tips" v-html="content"></p>
 </template>
 
 <script>


### PR DESCRIPTION
This allows HTML markup in text to parse so we can use text colors and other effects. Could be potentially breaking the layout if other HTML is parsed, so maybe filtering it would be a good idea. Or it could be an additional param to turn it on if needed.